### PR TITLE
APPCAFE: Add hack88 to fetch/create commands.

### DIFF
--- a/src-webui/appweb/dispatcher
+++ b/src-webui/appweb/dispatcher
@@ -1,6 +1,6 @@
 #!/bin/sh
 # License: BSD
-# Author: Kris Moore
+# Author: Kris Moore and Brandon Schneider
 # 
 # Dispatch script, run as root, allows www process to run 
 # specific commands with priv
@@ -162,10 +162,10 @@ run_queue_cmd()
 
 	if [ -n "$(sysctl -qn kern.features.vimage)" ] ; then
           # System has VIMAGE enabled
-          cmd="iocage fetch $target $tags tag=pbicage-$neworigin boot=on vnet=on dhcp=on bpf=on mount_linprocfs=1"
+          cmd="iocage fetch $target $tags tag=pbicage-$neworigin boot=on vnet=on dhcp=on bpf=on mount_linprocfs=1 hack88=1"
 	else
 	  # No VIMAGE, use fallback method
-	  cmd="iocage fetch $target $tags tag=pbicage-$neworigin boot=on ip4_addr=DEFAULT|AUTOIP4 mount_linprocfs=1"
+	  cmd="iocage fetch $target $tags tag=pbicage-$neworigin boot=on ip4_addr=DEFAULT|AUTOIP4 mount_linprocfs=1 hack88=1"
 	fi
      fi 
      # Regular jail creation
@@ -192,13 +192,13 @@ run_queue_cmd()
 	if [ -n "$(sysctl -qn kern.features.vimage)" ] ; then
           # System has VIMAGE enabled
 	  if [ -n "$customipv4" -a "$customipv4" != "" ] ; then
-            cmd="iocage create tag=pbijail-$newtag ip4_addr=$IPFLAGS mount_linprocfs=1 $tags"
+            cmd="iocage create tag=pbijail-$newtag ip4_addr=$IPFLAGS mount_linprocfs=1 hack88=1 $tags"
 	  else
-            cmd="iocage create tag=pbijail-$newtag boot=on vnet=on dhcp=on bpf=on mount_linprocfs=1 $tags"
+            cmd="iocage create tag=pbijail-$newtag boot=on vnet=on dhcp=on bpf=on mount_linprocfs=1 hack88=1 $tags"
 	  fi
 	else
 	  # No VIMAGE, use fallback method
-	  cmd="iocage create tag=pbijail-$newtag boot=on ip4_addr=$IPFLAGS mount_linprocfs=1 $tags"
+	  cmd="iocage create tag=pbijail-$newtag boot=on ip4_addr=$IPFLAGS mount_linprocfs=1 hack88=1 $tags"
 	fi
      fi
      if [ "$origin" = "destroy" ] ; then


### PR DESCRIPTION
This helps avoid an issue when the user supplies a new directory to mount in the jail. Since the path is too long, it doesn't go quite as planned.